### PR TITLE
Fix wrong arXiv link

### DIFF
--- a/docs/en/awesome_mixups/Mixup_SL.md
+++ b/docs/en/awesome_mixups/Mixup_SL.md
@@ -12,7 +12,7 @@ We are working on a survey of mixup methods. The list of awesome mixup methods i
 * **MixUp**: Hongyi Zhang, Moustapha Cisse, Yann N. Dauphin, David Lopez-Paz.
    - mixup: Beyond Empirical Risk Minimization. [[ICLR'2018](https://arxiv.org/abs/1710.09412)] [[code](https://github.com/facebookresearch/mixup-cifar10)]
 * **AdaMixup**: Hongyu Guo, Yongyi Mao, Richong Zhang.
-   - MixUp as Locally Linear Out-Of-Manifold Regularization. [[AAAI'2019](https://arxiv.org/abs/1710.09412)]
+   - MixUp as Locally Linear Out-Of-Manifold Regularization. [[AAAI'2019](https://arxiv.org/abs/1809.02499)]
 * **CutMix**: Sangdoo Yun, Dongyoon Han, Seong Joon Oh, Sanghyuk Chun, Junsuk Choe, Youngjoon Yoo.
    - CutMix: Regularization Strategy to Train Strong Classifiers with Localizable Features. [[ICCV'2019](https://arxiv.org/abs/1905.04899)] [[code](https://github.com/clovaai/CutMix-PyTorch)]
 * **ManifoldMix**: Vikas Verma, Alex Lamb, Christopher Beckham, Amir Najafi, Ioannis Mitliagkas, David Lopez-Paz, Yoshua Bengio.


### PR DESCRIPTION
Thanks for your contribution to OpenMixup and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. We follow the standard in MMLab, e.g., [MMClassification](https://github.com/open-mmlab/mmclassification). If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the wrong arXiv link for the paper "MixUp as Locally Linear Out-Of-Manifold Regularization."

## Modification

Change arXiv link

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
